### PR TITLE
JPype-py3 is now deprecated

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
         ],
     },
     install_requires=[
-        'JPype1-py3',
+        'JPype1',
         'charade',
     ],
     author='Aditya Kresna Permana',


### PR DESCRIPTION
see issue #29 for more details: https://github.com/tcalmant/jpype-py3/issues/29
Please use this version instead: https://github.com/jpype-project/jpype
It can be installed using pypi package: pip install JPype1