### PR TITLE
Remove local github.com dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ DATAPATH = join(abspath(dirname((__file__))), 'src/boilerpipe/data')
 
 
 def download_jars(datapath, version=boilerpipe_version):
-    tgz_url = 'https://github.com/slaveofcode/boilerpipe3/raw/master/boilerpipe-{0}-bin.tar.gz'.format(version)
+    tgz_url = './boilerpipe-{0}-bin.tar.gz'.format(version)
     tgz_name = basename(tgz_url)
 
     if not exists(tgz_name):


### PR DESCRIPTION
Build machines do not have access to the external network and accessing the github.com repo directly is a breaking requirement.

Changed to reference the zipped boilerpipe library locally. 