### PR TITLE
added html highlighting interface to Extractor class

### DIFF
--- a/src/boilerpipe/extract/__init__.py
+++ b/src/boilerpipe/extract/__init__.py
@@ -73,6 +73,10 @@ class Extractor(object):
     def getHTML(self):
         highlighter = HTMLHighlighter.newExtractingInstance()
         return highlighter.process(self.source, self.data)
+
+    def getHighlightedHTML(self):
+        highlighter = HTMLHighlighter.newHighlightingInstance()
+        return highlighter.process(self.source, self.data)
     
     def getImages(self):
         extractor = jpype.JClass(


### PR DESCRIPTION
Hi,

     First of all thank you for your work! 

I needed an interface to get the full html with the boilerplate marks, not just the extracted html (boilerplate removed), so I added a new function to the Extractor class ( getHighlightedHTML(self) ). Hope this is useful for someone else as well.

     Would be great if you have the time to review this and add this to the repo and pypi. 

Cheers!